### PR TITLE
MIS-identified particles, IM Lambda vs IM Sigma

### DIFF
--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -293,7 +293,7 @@ void Codecuts::CodeCuts(){
       
     h_MissingMass->Fill(Wneutron_kaon.M());
     h_MissingMass_kaonpion->Fill(Wneutron_pion.M());
-    //h_MissingPvsMass->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
+    //h_MissingPvsIMMass->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
     h_MissingMass_vsMissingMasskaonpion[0]->Fill(Wneutron_kaon.M(), Wneutron_pion.M());
 
       
@@ -310,10 +310,10 @@ void Codecuts::CodeCuts(){
      //----------Correlación momentums vs missing mass------------------------//
       
     if( Lambda.M()<1.11 || Lambda.M()>1.132) 
-      h_MissingPvsMass[0]->Fill(Sigma.M(),Wneutron_kaon.P());
+      h_MissingPvsIMMass[0]->Fill(Sigma.M(),Wneutron_kaon.P());
     
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
-      h_MissingPvsMass[1]->Fill(Lambda.M(),Wneutron_kaon.P());
+      h_MissingPvsIMMass[1]->Fill(Lambda.M(),Wneutron_kaon.P());
 
      h_MissingMassvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.P());
     

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -284,11 +284,11 @@ void Codecuts::CodeCuts(){
     Neutron.SetXYZM(Wneutron_kaon.Px(), Wneutron_kaon.Py(), Wneutron_kaon.Pz(), 0.939);
     Sigma = pion + Neutron;
     Lambda = pion + proton;
-    MMSigma= photon + deuteron - proton - kaon; //This it to make correlation with invariant mass (lambda)
+    MMSigma= photon + deuteron - proton - kaon;              			// Correlation with invariant mass (lambda)
     
-    WBoost = photon + deuteron; // to make Boost
+    WBoost = photon + deuteron; 						// to make Boost
       
-    Wneutron_pion = photon + deuteron - proton - kaonpion - pion;         // This missing mass is with the Pion-
+    Wneutron_pion = photon + deuteron - proton - kaonpion - pion;        	// This missing mass is with the Pion-
       
       
     h_MissingMass->Fill(Wneutron_kaon.M());
@@ -311,7 +311,6 @@ void Codecuts::CodeCuts(){
     //Double_t El = TMath::Power((Wneutron_kaon.M()-offsetx)*cos(angle)+(Wneutron_pion.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
     //+TMath::Power((Wneutron_kaon.M()-offsetx)*sin(angle)-(Wneutron_pion.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
     //if(El > 1) continue;
-     
     
     h_MissingMasscut->Fill(Wneutron_kaon.M());
     h_MissingMass_kaonpioncut->Fill(Wneutron_pion.M());
@@ -325,9 +324,9 @@ void Codecuts::CodeCuts(){
     h_LambdaMass->Fill(Lambda.M());
     h_InvMassLambda_vsInvMassSigma->Fill(Sigma.M(), Lambda.M());
     h_MMassSigma->Fill(MMSigma.M());
-    h_InvMassLambda_vsMMassSigma->Fill(MMSigma.M(), Lambda.M());
-      
-      
+    h_MMNeutron_vsMMassSigma[0]->Fill(Wneutron_kaon.M(),MMSigma.M());
+
+
     //------------------------Comparación de sigmas-------------//
     if( Lambda.M()<1.108 || Lambda.M()>1.124)
       h_InvariantMasscut[0]->Fill(Sigma.M());
@@ -342,14 +341,10 @@ void Codecuts::CodeCuts(){
     //------------- Comparación de missing momentums-----------//
       
     if( Lambda.M()<1.096 || Lambda.M()>1.136) 
-      h_MissingP[0]->Fill(Wneutron_kaon.P());
-      
-      
-      
+      h_MissingP[0]->Fill(Wneutron_kaon.P());   
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
       h_MissingP[1]->Fill(Wneutron_kaon.P());
-           
-    if ( Lambda.M()>=1.11 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 3sigma
+    if ( Lambda.M()>=1.1 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 8sigma
     Events[16]++;         //Events With Lambda cuts
 
     
@@ -357,6 +352,7 @@ void Codecuts::CodeCuts(){
     if(Wneutron_kaon.P()<=0.2) continue;                                    //Cut for rescattering
     Events[18]++;         //Events With Neutron Rescattering Lambada cuts
 
+    h_MMNeutron_vsMMassSigma[1]->Fill(Wneutron_kaon.M(),MMSigma.M());       //Cut MM neutron and MM sigma 
     h_InvariantMasscut[3]->Fill(Sigma.M());
     h_MissingMassvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.M());
       

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -411,7 +411,7 @@ void Codecuts::CodeCuts(){
       if(KaonCosThetaCM < 0.51){
 	MEASPhi.at(0).push_back(KaonPhiCM);
 	MEASGammaP.at(0).push_back(PhotoPol);
-	h_kaonPhiPA[0]->Fill(KaonPhiCM);c
+	h_kaonPhiPA[0]->Fill(KaonPhiCM);
       }
       else if (KaonCosThetaCM > 0.51){
 	MEASPhi.at(1).push_back(KaonPhiCM);

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -268,7 +268,7 @@ void Codecuts::CodeCuts(){
 
     //-------------- Reconstruction --------- //
       
-    TLorentzVector photon, deuteron, kaon, kaonpion, proton, pion, Wneutron_kaon, Wneutron_pion, Sigma, Lambda, Neutron, WBoost;
+    TLorentzVector photon, deuteron, kaon, kaonpion, proton, pion, Wneutron_kaon, Wneutron_pion, Sigma, Lambda, Neutron, WBoost, MMSigma;
     photon.SetXYZM(0,0,myDataList->getTAGR_epho(myDataList->getIndex_k(0)),0);
     deuteron.SetXYZM(0,0,0,1.8756);
     double Px_kaonpion = myDataList->getEVNT_track(1).Rho()* sin(myDataList->getEVNT_track(1).Theta())* cos(myDataList->getEVNT_track(1).Phi());
@@ -284,6 +284,8 @@ void Codecuts::CodeCuts(){
     Neutron.SetXYZM(Wneutron_kaon.Px(), Wneutron_kaon.Py(), Wneutron_kaon.Pz(), 0.939);
     Sigma = pion + Neutron;
     Lambda = pion + proton;
+    MMSigma= photon + deuteron - proton - kaon; //This it to make correlation with invariant mass (lambda)
+    
     WBoost = photon + deuteron; // to make Boost
       
     Wneutron_pion = photon + deuteron - proton - kaonpion - pion;         // This missing mass is with the Pion-
@@ -304,12 +306,12 @@ void Codecuts::CodeCuts(){
       h_MissingPvsMass[1]->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
       
       
-      
-    Double_t El = TMath::Power((Wneutron_kaon.M()-offsetx)*cos(angle)+(Wneutron_pion.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
-      +TMath::Power((Wneutron_kaon.M()-offsetx)*sin(angle)-(Wneutron_pion.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
-      
-    if(El > 1) continue;
-    Events[15]++;         //Events With NOT PION, YES Kaon 
+    if ( Wneutron_pion.M() < 0.98) continue;       //Cut from correlation MM  
+    Events[15]++;         //Events With NOT PION, YES Kaon
+    //Double_t El = TMath::Power((Wneutron_kaon.M()-offsetx)*cos(angle)+(Wneutron_pion.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
+    //+TMath::Power((Wneutron_kaon.M()-offsetx)*sin(angle)-(Wneutron_pion.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
+    //if(El > 1) continue;
+     
     
     h_MissingMasscut->Fill(Wneutron_kaon.M());
     h_MissingMass_kaonpioncut->Fill(Wneutron_pion.M());
@@ -321,6 +323,9 @@ void Codecuts::CodeCuts(){
           
     h_InvariantMass->Fill(Sigma.M());
     h_LambdaMass->Fill(Lambda.M());
+    h_InvMassLambda_vsInvMassSigma->Fill(Sigma.M(), Lambda.M());
+    h_MMassSigma->Fill(MMSigma.M());
+    h_InvMassLambda_vsMMassSigma->Fill(MMSigma.M(), Lambda.M());
       
       
     //------------------------Comparación de sigmas-------------//
@@ -343,12 +348,12 @@ void Codecuts::CodeCuts(){
       
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
       h_MissingP[1]->Fill(Wneutron_kaon.P());
-      
-      
+           
     if ( Lambda.M()>=1.11 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 3sigma
     Events[16]++;         //Events With Lambda cuts
-    if ( Wneutron_kaon.M()<=0.9 || Wneutron_kaon.M()>=0.96 ) continue;       //Cut from correlation MM
-    Events[17]++;         //Events With Mass neutron range
+
+    
+    // Events[17]++;         //Events With Mass neutron range
     if(Wneutron_kaon.P()<=0.2) continue;                                    //Cut for rescattering
     Events[18]++;         //Events With Neutron Rescattering Lambada cuts
 

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -1,9 +1,10 @@
+#ifndef CODECUTS_H
+#define CODECUTS_H
+
 #include "./Histograms.h"
 #include "./include/Libraries.h"
 #include "./include/Miscelaneous.h"
-
-#ifndef CODECUTS_H
-#define CODECUTS_H
+#include "./src/DataEvent.cpp"
 
 class Codecuts : public Histograms {
 
@@ -104,11 +105,7 @@ void Codecuts::CodeCuts(){
     Events[3]++;         //Events With DeltaB cut
     if(deltbetacut[1] > 0.025 || deltbetacut[1] < -0.025) continue;
     Events[4]++;         //Events With DeltaB cut
-    
-    
-    
-    
-   
+       
     //------------------Correlation Theta-Phi, -----------------------/
     
     h_ThePhi[0]->Fill(myDataList->getEVNT_track(0).Phi()*TMath::RadToDeg(), myDataList->getEVNT_track(0).Theta()*TMath::RadToDeg());  
@@ -304,7 +301,10 @@ void Codecuts::CodeCuts(){
     MMNeut_PiK 	= photon + deuteron - proton - pionkaon - kaon;     	   	// This missing mass is with the Kaon-      
       
     h_MissingMass->Fill(MMNeut_kaon.M());
+
     h_MissingMass_kaonpion->Fill(MMNeut_KPi.M());
+    h_MissingMass_kaonproton->Fill(MMNeut_KP.M());
+    h_MissingMass_pionkaon->Fill(MMNeut_PiK.M());
     //h_MissingPvsIMMass->Fill(MMNeut_kaon.M(),MMNeut_kaon.P());
     h_MissingMass_vsMissingMasskaonpion[0]->Fill(MMNeut_kaon.M(), MMNeut_KPi.M());
     h_MissingMass_vsMissingMasskaonproton[0]->Fill(MMNeut_kaon.M(),MMNeut_KP.M());
@@ -313,16 +313,19 @@ void Codecuts::CodeCuts(){
             
     
     if(MMNeut_KPi.M() < 0.98) continue;       //Cut from correlation MM
+    h_MissingMass_vsMissingMasskaonpion[1]->Fill(MMNeut_kaon.M(), MMNeut_KPi.M());
     if(MMNeut_KP.M()  > 0.75) continue; 
+    h_MissingMass_vsMissingMasskaonproton[1]->Fill(MMNeut_kaon.M(),MMNeut_KP.M());
     if(MMNeut_PiK.M() > 0.70) continue; 
+    h_MissingMass_vsMissingMasspionkaon[1]->Fill(MMNeut_kaon.M(),MMNeut_PiK.M());
     Events[15]++;         //Events With NOT PION, YES Kaon
     // Double_t El = TMath::Power((proton.P()-offsetx)*cos(angle)+(MMSigma.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
     //   +TMath::Power((proton.P()-offsetx)*sin(angle)-(MMSigma.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
     // if(El <= 1) continue;
     
-    h_MissingMass_vsMissingMasskaonpion[1]->Fill(MMNeut_kaon.M(), MMNeut_KPi.M());
-    h_MissingMass_vsMissingMasskaonproton[1]->Fill(MMNeut_kaon.M(),MMNeut_KP.M());
-    h_MissingMass_vsMissingMasspionkaon[1]->Fill(MMNeut_kaon.M(),MMNeut_PiK.M());
+
+
+
     
     //----------Correlación momentums vs missing mass------------------------//
       
@@ -405,12 +408,12 @@ void Codecuts::CodeCuts(){
     //0 is for PARA
     //1 is for PERP
     if (myDataList->getCoh_plan()==0){
-      if(KaonCosThetaCM < 0.668){
+      if(KaonCosThetaCM < 0.51){
 	MEASPhi.at(0).push_back(KaonPhiCM);
 	MEASGammaP.at(0).push_back(PhotoPol);
-	h_kaonPhiPA[0]->Fill(KaonPhiCM);
+	h_kaonPhiPA[0]->Fill(KaonPhiCM);c
       }
-      else if (KaonCosThetaCM > 0.668){
+      else if (KaonCosThetaCM > 0.51){
 	MEASPhi.at(1).push_back(KaonPhiCM);
 	MEASGammaP.at(1).push_back(PhotoPol);
 	h_kaonPhiPA[1]->Fill(KaonPhiCM);
@@ -418,18 +421,19 @@ void Codecuts::CodeCuts(){
     }
       
     else if (myDataList->getCoh_plan()==1){
-      if(KaonCosThetaCM < 0.668){
+      if(KaonCosThetaCM < 0.51){
 	MEASPhi.at(0).push_back(KaonPhiCM);
 	MEASGammaP.at(0).push_back(-PhotoPol);
 	h_kaonPhiPE[0]->Fill(KaonPhiCM);
       }
-      else if (KaonCosThetaCM > 0.668){
+      else if (KaonCosThetaCM > 0.51){
 	MEASPhi.at(1).push_back(KaonPhiCM);
 	MEASGammaP.at(1).push_back(-PhotoPol);
 	h_kaonPhiPE[1]->Fill(KaonPhiCM);
       }
     }
-     
+
+
     //---------------Asymmetry Analysis----------------//
       
     h_Asym[0]=(TH1F*)h_kaonPhiPA[0]->GetAsymmetry(h_kaonPhiPE[0]);

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -268,70 +268,86 @@ void Codecuts::CodeCuts(){
 
     //-------------- Reconstruction --------- //
       
-    TLorentzVector photon, deuteron, kaon, kaonpion, proton, pion, Wneutron_kaon, Wneutron_pion, Sigma, Lambda, Neutron, WBoost, MMSigma;
+    TLorentzVector photon, deuteron, kaon, proton ,pion, Neutron, WBoost;			//Principal Reaction
+    TLorentzVector kaonpion, kaonproton, pionkaon;						//MIS-identification particles
+    TLorentzVector MMNeut_kaon, MMNeut_KPi, MMNeut_KP, MMNeut_PiK ,MMSigma;			//Missing mass
+    TLorentzVector Sigma, Lambda;								//Invariant Mass
+    
     photon.SetXYZM(0,0,myDataList->getTAGR_epho(myDataList->getIndex_k(0)),0);
     deuteron.SetXYZM(0,0,0,1.8756);
+    
     double Px_kaonpion = myDataList->getEVNT_track(1).Rho()* sin(myDataList->getEVNT_track(1).Theta())* cos(myDataList->getEVNT_track(1).Phi());
     double Py_kaonpion = myDataList->getEVNT_track(1).Rho()* sin(myDataList->getEVNT_track(1).Theta())* sin(myDataList->getEVNT_track(1).Phi());
     double Pz_kaonpion = myDataList->getEVNT_track(1).Rho()*(myDataList->getEVNT_track(1).CosTheta());
-    kaonpion.SetXYZM(Px_kaonpion, Py_kaonpion, Pz_kaonpion, 0.139);       // This mass is of Pion-, because we need remove the background of Pion-
-      
-      
-    proton = myDataList->geteloss_track(0);
-    kaon = myDataList->geteloss_track(1);
-    pion = myDataList->geteloss_track(2);
-    Wneutron_kaon = photon + deuteron - proton - kaon - pion;
-    Neutron.SetXYZM(Wneutron_kaon.Px(), Wneutron_kaon.Py(), Wneutron_kaon.Pz(), 0.939);
-    Sigma = pion + Neutron;
-    Lambda = pion + proton;
-    MMSigma= photon + deuteron - proton - kaon;              			// Correlation with invariant mass (lambda)
-    
-    WBoost = photon + deuteron; 						// to make Boost
-      
-    Wneutron_pion = photon + deuteron - proton - kaonpion - pion;        	// This missing mass is with the Pion-
-      
-      
-    h_MissingMass->Fill(Wneutron_kaon.M());
-    h_MissingMass_kaonpion->Fill(Wneutron_pion.M());
-    //h_MissingPvsIMMass->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
-    h_MissingMass_vsMissingMasskaonpion[0]->Fill(Wneutron_kaon.M(), Wneutron_pion.M());
 
-      
-   
+    double Px_pionkaon = myDataList->getEVNT_track(2).Rho()* sin(myDataList->getEVNT_track(2).Theta())* cos(myDataList->getEVNT_track(2).Phi());
+    double Py_pionkaon = myDataList->getEVNT_track(2).Rho()* sin(myDataList->getEVNT_track(2).Theta())* sin(myDataList->getEVNT_track(2).Phi());
+    double Pz_pionkaon = myDataList->getEVNT_track(2).Rho()*(myDataList->getEVNT_track(2).CosTheta());
+
+    // This mass is of Pion-, because we need remove the background of Pion-
+    kaonpion.SetXYZM(Px_kaonpion, Py_kaonpion, Pz_kaonpion, 0.139);       			
+    kaonproton.SetXYZM(Px_kaonpion, Py_kaonpion, Pz_kaonpion,0.9383);
+    pionkaon.SetXYZM(Px_pionkaon, Py_pionkaon, Pz_pionkaon,0.4937);
     
+    proton 	= myDataList->geteloss_track(0);
+    kaon 	= myDataList->geteloss_track(1);
+    pion 	= myDataList->geteloss_track(2);
+    MMNeut_kaon = photon + deuteron - proton - kaon - pion;
+    Neutron.SetXYZM(MMNeut_kaon.Px(), MMNeut_kaon.Py(), MMNeut_kaon.Pz(), 0.939);
+    Sigma 	= pion + Neutron;
+    Lambda 	= pion + proton;
+    MMSigma  	= photon + deuteron - proton - kaon;           			// Correlation with invariant mass (lambda)
+    WBoost   	= photon + deuteron; 						// to make Boost
       
+    MMNeut_KPi 	= photon + deuteron - proton - kaonpion - pion;     	   	// This missing mass is with the Pion-
+    MMNeut_KP	= photon + deuteron - proton - kaonproton - pion;     	   	// This missing mass is with the Proton
+    MMNeut_PiK 	= photon + deuteron - proton - pionkaon - kaon;     	   	// This missing mass is with the Kaon-      
       
-    if ( Wneutron_pion.M() < 0.98) continue;       //Cut from correlation MM  
+    h_MissingMass->Fill(MMNeut_kaon.M());
+    h_MissingMass_kaonpion->Fill(MMNeut_KPi.M());
+    //h_MissingPvsIMMass->Fill(MMNeut_kaon.M(),MMNeut_kaon.P());
+    h_MissingMass_vsMissingMasskaonpion[0]->Fill(MMNeut_kaon.M(), MMNeut_KPi.M());
+    h_MissingMass_vsMissingMasskaonproton[0]->Fill(MMNeut_kaon.M(),MMNeut_KP.M());
+    h_MissingMass_vsMissingMasspionkaon[0]->Fill(MMNeut_kaon.M(),MMNeut_PiK.M());
+    
+            
+    
+    if(MMNeut_KPi.M() < 0.98) continue;       //Cut from correlation MM
+    if(MMNeut_KP.M()  > 0.75) continue; 
+    if(MMNeut_PiK.M() > 0.70) continue; 
     Events[15]++;         //Events With NOT PION, YES Kaon
-    //Double_t El = TMath::Power((Wneutron_kaon.M()-offsetx)*cos(angle)+(Wneutron_pion.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
-    //+TMath::Power((Wneutron_kaon.M()-offsetx)*sin(angle)-(Wneutron_pion.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
-    //if(El > 1) continue;
-
-     //----------Correlación momentums vs missing mass------------------------//
+    // Double_t El = TMath::Power((proton.P()-offsetx)*cos(angle)+(MMSigma.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
+    //   +TMath::Power((proton.P()-offsetx)*sin(angle)-(MMSigma.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
+    // if(El <= 1) continue;
+    
+    h_MissingMass_vsMissingMasskaonpion[1]->Fill(MMNeut_kaon.M(), MMNeut_KPi.M());
+    h_MissingMass_vsMissingMasskaonproton[1]->Fill(MMNeut_kaon.M(),MMNeut_KP.M());
+    h_MissingMass_vsMissingMasspionkaon[1]->Fill(MMNeut_kaon.M(),MMNeut_PiK.M());
+    
+    //----------Correlación momentums vs missing mass------------------------//
       
     if( Lambda.M()<1.11 || Lambda.M()>1.132) 
-      h_MissingPvsIMMass[0]->Fill(Sigma.M(),Wneutron_kaon.P());
+      h_MissingPvsIMMass[0]->Fill(Sigma.M(),MMNeut_kaon.P());
     
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
-      h_MissingPvsIMMass[1]->Fill(Lambda.M(),Wneutron_kaon.P());
+      h_MissingPvsIMMass[1]->Fill(Lambda.M(),MMNeut_kaon.P());
 
-     h_MissingMassvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.P());
+     h_MissingMassvsSigmaMass->Fill(Sigma.M(), MMNeut_kaon.P());
     
-    h_MissingMasscut->Fill(Wneutron_kaon.M());
-    h_MissingMass_kaonpioncut->Fill(Wneutron_pion.M());
+    h_MissingMasscut->Fill(MMNeut_kaon.M());
+    h_MissingMass_kaonpioncut->Fill(MMNeut_KPi.M());
       
-    // h_MissingP->Fill(Wneutron_kaon.P());
+    // h_MissingP->Fill(MMNeut_kaon.P());
       
-    h_MissingPvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.P());
-    h_MissingMass_vsMissingMasskaonpion[1]->Fill(Wneutron_kaon.M(), Wneutron_pion.M());
+    h_MissingPvsSigmaMass->Fill(Sigma.M(), MMNeut_kaon.P());
           
     h_InvariantMass->Fill(Sigma.M());
     h_LambdaMass->Fill(Lambda.M());
     h_InvMassLambda_vsInvMassSigma->Fill(Sigma.M(), Lambda.M());
     h_MMassSigma->Fill(MMSigma.M());
-    h_MMNeutron_vsMMassSigma[0]->Fill(Wneutron_kaon.M(),MMSigma.M());
+    h_MMNeutron_vsMMassSigma[0]->Fill(MMNeut_kaon.M(),MMSigma.M());
 
-
+    
     //------------------------Comparación de sigmas-------------//
     if( Lambda.M()<1.108 || Lambda.M()>1.124)
       h_InvariantMasscut[0]->Fill(Sigma.M());
@@ -346,9 +362,10 @@ void Codecuts::CodeCuts(){
     //------------- Comparación de missing momentums-----------//
       
     if( Lambda.M()<1.096 || Lambda.M()>1.136) 
-      h_MissingP[0]->Fill(Wneutron_kaon.P());   
+      h_MissingP[0]->Fill(MMNeut_kaon.P());   
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
-      h_MissingP[1]->Fill(Wneutron_kaon.P());
+      h_MissingP[1]->Fill(MMNeut_kaon.P());
+
 
     if ( Lambda.M()>=1.1 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 8sigma
     Events[16]++;         //Events With Lambda cuts
@@ -358,19 +375,19 @@ void Codecuts::CodeCuts(){
     h_CorrelationMMomentum->Fill(Sigma.P(), Lambda.P());
     
     // Events[17]++;         //Events With Mass neutron range
-    if(Wneutron_kaon.P()<=0.2) continue;                                    //Cut for rescattering
+    if(MMNeut_kaon.P()<=0.2) continue;                                    //Cut for rescattering
     Events[18]++;         //Events With Neutron Rescattering Lambada cuts
 
 
-    h_MMNeutron_vsMMassSigma[1]->Fill(Wneutron_kaon.M(),MMSigma.M());       //Cut MM neutron and MM sigma 
+    h_MMNeutron_vsMMassSigma[1]->Fill(MMNeut_kaon.M(),MMSigma.M());       //Cut MM neutron and MM sigma 
     h_InvariantMasscut[3]->Fill(Sigma.M());
    
     h_MMassSigmaCut->Fill(MMSigma.M());
       
     // Pion -  (Por si las moscas)
     h_DeltaBVSInvariantMass->Fill(Sigma.M(),deltbeta[2]);
-    h_DeltaBVSMissingMass->Fill(Wneutron_kaon.M(),deltbeta[2]);
-    h_DeltaBVSMissingMomentum->Fill(Wneutron_kaon.P(),deltbeta[2]);
+    h_DeltaBVSMissingMass->Fill(MMNeut_kaon.M(),deltbeta[2]);
+    h_DeltaBVSMissingMomentum->Fill(MMNeut_kaon.P(),deltbeta[2]);
 
     //------------Momentum proton----------------.//
     h_MomentumProton->Fill(proton.P());

--- a/CodeCuts/CodeCuts.h
+++ b/CodeCuts/CodeCuts.h
@@ -297,13 +297,8 @@ void Codecuts::CodeCuts(){
     h_MissingMass_vsMissingMasskaonpion[0]->Fill(Wneutron_kaon.M(), Wneutron_pion.M());
 
       
-    //----------Correlación momentums vs missing mass------------------------//
-      
-    if( Lambda.M()<1.11 || Lambda.M()>1.132) 
-      h_MissingPvsMass[0]->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
-      
-    if( Sigma.M()<1.08 || Sigma.M()>1.3)
-      h_MissingPvsMass[1]->Fill(Wneutron_kaon.M(),Wneutron_kaon.P());
+   
+    
       
       
     if ( Wneutron_pion.M() < 0.98) continue;       //Cut from correlation MM  
@@ -311,7 +306,16 @@ void Codecuts::CodeCuts(){
     //Double_t El = TMath::Power((Wneutron_kaon.M()-offsetx)*cos(angle)+(Wneutron_pion.M()-offsety)*sin(angle),2)/TMath::Power(radx,2)
     //+TMath::Power((Wneutron_kaon.M()-offsetx)*sin(angle)-(Wneutron_pion.M()-offsety)*cos(angle),2)/TMath::Power(rady,2);
     //if(El > 1) continue;
-     
+
+     //----------Correlación momentums vs missing mass------------------------//
+      
+    if( Lambda.M()<1.11 || Lambda.M()>1.132) 
+      h_MissingPvsMass[0]->Fill(Sigma.M(),Wneutron_kaon.P());
+    
+    if( Sigma.M()<1.08 || Sigma.M()>1.3)
+      h_MissingPvsMass[1]->Fill(Lambda.M(),Wneutron_kaon.P());
+
+     h_MissingMassvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.P());
     
     h_MissingMasscut->Fill(Wneutron_kaon.M());
     h_MissingMass_kaonpioncut->Fill(Wneutron_pion.M());
@@ -349,23 +353,29 @@ void Codecuts::CodeCuts(){
     if( Sigma.M()<1.08 || Sigma.M()>1.3)
       h_MissingP[1]->Fill(Wneutron_kaon.P());
            
-    if ( Lambda.M()>=1.11 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 3sigma
+    if ( Lambda.M()>=1.1 && Lambda.M()<=1.132) continue;                   //Cut for LamdaMass in +/- 8sigma
     Events[16]++;         //Events With Lambda cuts
 
+
+    //--------Correlation Momentums--------------//
+    h_CorrelationMMomentum->Fill(Sigma.P(), Lambda.P());
     
     // Events[17]++;         //Events With Mass neutron range
     if(Wneutron_kaon.P()<=0.2) continue;                                    //Cut for rescattering
     Events[18]++;         //Events With Neutron Rescattering Lambada cuts
 
+  
     h_InvariantMasscut[3]->Fill(Sigma.M());
-    h_MissingMassvsSigmaMass->Fill(Sigma.M(), Wneutron_kaon.M());
+   
+    h_MMassSigmaCut->Fill(MMSigma.M());
       
     // Pion -  (Por si las moscas)
     h_DeltaBVSInvariantMass->Fill(Sigma.M(),deltbeta[2]);
     h_DeltaBVSMissingMass->Fill(Wneutron_kaon.M(),deltbeta[2]);
     h_DeltaBVSMissingMomentum->Fill(Wneutron_kaon.P(),deltbeta[2]);
 
-
+    //------------Momentum proton----------------.//
+    h_MomentumProton->Fill(proton.P());
    
     //-----------------BOOST------------------------------//
 

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -57,8 +57,9 @@ protected:
   TH1F *h_MissingMasscut                  = NULL;
   TH1F *h_MissingMass_kaonpioncut         = NULL;
   
-  TH2F *h_MissingMass_vsMissingMasskaonpion[2] = {};
-
+  TH2F *h_MissingMass_vsMissingMasskaonpion[2] 		= {};
+  TH2F *h_MissingMass_vsMissingMasskaonproton[2] 	= {};
+  TH2F *h_MissingMass_vsMissingMasspionkaon[2] 		= {};
 
   TH1F *h_MissingP[2]                      = {};
   TH1F *h_MissingPcut[2]                   = {};
@@ -93,9 +94,9 @@ protected:
 
   //--- Ellipse Cuts ---- //
   
-  // TEllipse *myEllipse                     = NULL;
-  //double radx=0.034, rady=0.02, offsetx=0.937, offsety=1.047, angle=70*TMath::DegToRad();
-  
+  TEllipse *myEllipse                     = NULL;
+  double radx=0.1569373, rady=0.03295391, offsetx=0.5972416, offsety=1.153089-0.02, angle=360*TMath::DegToRad();
+  double radx1=0.12744, rady1=0.01959062, offsetx1=1.152367, offsety1=1.199867, angle1=360*TMath::DegToRad();
   //-----Correlation Theta-Phi, ----------//
  
   TH2F *h_ThePhi[3]                         = {};
@@ -109,6 +110,9 @@ protected:
 
   //-------Momentum proton------------------//
   TH1F *h_MomentumProton                    = NULL;
+  TH2F *h_CorrIvan[3]                       = {};
+  TH1F *h_CorrIvanM			    = NULL; 
+  
   //-----Kaon phi-------------------//
   TH1F *h_kaonPhiPA[2]                      = {};
   TH1F *h_kaonPhiPE[2]                      = {};
@@ -255,14 +259,28 @@ void Histograms::DoHistograms(){
 				       100, 0.7, 1.2);
 
   
-  h_MissingMass_vsMissingMasskaonpion[0] = new TH2F("MissingMass_correlation",
-						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]",
-						    100, 0.7, 1.2, 100, 0.7, 1.2);
 
-  h_MissingMass_vsMissingMasskaonpion[1] = new TH2F("MissingMass_correlation_Cut",
+  h_MissingMass_vsMissingMasskaonpion[0] = new TH2F("MissingMass_correlationKaonPion",
 						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]",
-						    100, 0.7, 1.2, 100, 0.7, 1.2);
-  
+						    300, 0.7, 1.2, 300, 0.7, 1.2);
+
+  h_MissingMass_vsMissingMasskaonpion[1] = new TH2F("MissingMass_correlationKaonPion_Cut",
+						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]",
+						    300, 0.7, 1.2, 300, 0.7, 1.2);
+
+  h_MissingMass_vsMissingMasskaonproton[0] = new TH2F("MissingMass_correlationKaonProton",
+						      "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow p #pi^{-} X p) [GeV/c^{2}]",
+						      300, 0.7, 1.2, 300, 0, 1.2);
+  h_MissingMass_vsMissingMasskaonproton[1] = new TH2F("MissingMass_correlationKaonProton_Cut",
+						      "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow p #pi^{-} X p) [GeV/c^{2}]",
+						      300, 0.7, 1.2, 300, 0, 1.2);
+  h_MissingMass_vsMissingMasspionkaon[0] = new TH2F("MissingMass_correlationPionKaon",
+						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow K^{+} K^{-} X p) [GeV/c^{2}]",
+						      300, 0.7, 1.2, 300, 0, 1.2);
+  h_MissingMass_vsMissingMasspionkaon[0] = new TH2F("MissingMass_correlationPionKaon_Cut",
+						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow K^{+} K^{-} X p) [GeV/c^{2}]",
+						      300, 0.7, 1.2, 300, 0, 1.2);
+
   h_MissingP[0] = new TH1F("h_missingpSigma",
 			   "; Missing momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]; Frequency",
 			   100, 0.0, 1.);
@@ -326,8 +344,7 @@ void Histograms::DoHistograms(){
 			  "; Proton momentum [GeV/c]; Frequency ",
 			  100, 0, 2.0);
 
-  
-  //-------- Lambda and Lambda Fit ------ //
+   //-------- Lambda and Lambda Fit ------ //
   
   h_LambdaMass = new TH1F("h_LambdaMass",
 			  "; IM(#pi^{-} p) [GeV/c^{2}]; Frequency ",
@@ -843,7 +860,7 @@ void Histograms::DoCanvas(){
   h_MissingMass->Draw();
   c0MM->SaveAs("imagenes/MissingMass.eps");
 
-  //---------- MM Correlation without cut ---------------//
+  //---------- MM Kaon-Pion Correlation without cut ---------------//
   
   TCanvas *c0ELL=new TCanvas("c0ELL","Correlation of MM", 900, 500);
   c0ELL->cd(1);
@@ -858,9 +875,9 @@ void Histograms::DoCanvas(){
   //myEllipse->SetFillStyle(0);
   //myEllipse->SetLineColor(kRed);
   //myEllipse->Draw("same");
-  c0ELL->SaveAs("imagenes/Ellipse.eps");
+  c0ELL->SaveAs("imagenes/MIS_Identification_KPi.eps");
 
-  //---------- MM Correlation with cut ---------------//
+  //---------- MM Kaon-Pion Correlation with cut ---------------//
   
   TCanvas *c0ELLC=new TCanvas("c0ELLC","Correlation of MM", 900, 500);
   c0ELLC->cd(1);
@@ -869,10 +886,68 @@ void Histograms::DoCanvas(){
   //myEllipse->SetFillStyle(0);
   //myEllipse->SetLineColor(kRed);
   //myEllipse->Draw("same");
-  c0ELLC->SaveAs("imagenes/Ellipse_C.eps");
+  c0ELLC->SaveAs("imagenes/MIS_Identification_KPi_C.eps");
+
+  
+  //---------- MM Kaon-Proton Correlation without cut ---------------//
+  
+  TCanvas *c1ELL=new TCanvas("c1ELL","Correlation of MM", 900, 500);
+  c1ELL->cd(1);
+  h_MissingMass_vsMissingMasskaonproton[0]->SetTitleSize(0.045, "XY");  
+  h_MissingMass_vsMissingMasskaonproton[0]->Draw("colz");
+  TLine *MMCorrLine1;
+  MMCorrLine1 = new TLine(0.7, 0.75,1.2, 0.75);
+  MMCorrLine1->SetLineWidth(2);
+  MMCorrLine1->SetLineColor(2);
+  MMCorrLine1->Draw("same");
+  
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
+  c1ELL->SaveAs("imagenes/MIS_Identification_KP.eps");
+
+  //---------- MM Kaon-Proton Correlation with cut ---------------//
+  
+  TCanvas *c1ELLC=new TCanvas("c1ELLC","Correlation of MM", 900, 500);
+  c1ELLC->cd(1);
+  h_MissingMass_vsMissingMasskaonproton[1]->SetTitleSize(0.045, "XY");  
+  h_MissingMass_vsMissingMasskaonproton[1]->Draw("colz");
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
+  c1ELLC->SaveAs("imagenes/MIS_Identification_KP_C.eps");
+
+  
+  //---------- MM Pion-Kaon Correlation without cut ---------------//
+  
+  TCanvas *c2ELL=new TCanvas("c2ELL","Correlation of MM", 900, 500);
+  c2ELL->cd(1);
+  h_MissingMass_vsMissingMasspionkaon[0]->SetTitleSize(0.045, "XY");  
+  h_MissingMass_vsMissingMasspionkaon[0]->Draw("colz");
+  TLine *MMCorrLine2;
+  MMCorrLine2 = new TLine(0.7, 0.70,1.2, 0.70);
+  MMCorrLine2->SetLineWidth(2);
+  MMCorrLine2->SetLineColor(2);
+  MMCorrLine2->Draw("same");
+  
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
+  c2ELL->SaveAs("imagenes/MIS_Identification_PiK.eps");
+
+  //---------- MM Pion-Kaon Correlation with cut ---------------//
+  
+  TCanvas *c2ELLC=new TCanvas("c2ELLC","Correlation of MM", 900, 500);
+  c2ELLC->cd(1);
+  h_MissingMass_vsMissingMasspionkaon[1]->SetTitleSize(0.045, "XY");  
+  h_MissingMass_vsMissingMasspionkaon[1]->Draw("colz");
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
+  c2ELLC->SaveAs("imagenes/MIS_Identification_Pik_C.eps");
 
   //----------- MM After Cuts for MM correlation ------- //
-
+  
 
   //------ Kaon ------//  
   
@@ -910,7 +985,7 @@ void Histograms::DoCanvas(){
   MMC1.BoxOptStat("em");
   MMC1.BoxSize(0.7,0.7);
   MMC1.BoxPosition(0.75,(h_MissingMass_kaonpion->GetMaximum()/2),0.85,h_MissingMass_kaonpion->GetMaximum()+100);
-  MMC1.BoxTextSize(0.04);
+  MMC1.BoxTextSize(0.05);
   MMC1.SaveChanges();
   h_MissingMass_kaonpioncut->Draw("same");
 
@@ -1022,15 +1097,23 @@ void Histograms::DoCanvas(){
   h_MomentumProton->SetTitleSize(0.045, "XY");  
   h_MomentumProton->Draw();
   
-  cMP->SaveAs("imagenes/MomentumProton.eps");
-
-
+  cMP->SaveAs("imagenes/MomentumProton.eps");    
   
   //--------------Correlation Invariant masses (Lambda vs Sigma)----//
   TCanvas *cIMLS=new TCanvas("cIMLS","Correlation of Invariant masses", 900, 500);
   cIMLS->cd(1);
   h_InvMassLambda_vsInvMassSigma->SetTitleSize(0.045, "XY");  
   h_InvMassLambda_vsInvMassSigma->Draw("colz");
+  TLine *IMCorrLine1;
+  IMCorrLine1 = new TLine(1,1.1,1.4, 1.1);
+  IMCorrLine1->SetLineWidth(2);
+  IMCorrLine1->SetLineColor(2);
+  IMCorrLine1->Draw("same");
+  TLine *IMCorrLine2;
+  IMCorrLine2 = new TLine(1,1.132,1.4, 1.132);
+  IMCorrLine2->SetLineWidth(2);
+  IMCorrLine2->SetLineColor(2);
+  IMCorrLine2->Draw("same");
   
   cIMLS->SaveAs("imagenes/InvariantMassCorrelation.eps");
 

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -62,7 +62,7 @@ protected:
 
   TH1F *h_MissingP[2]                      = {};
   TH1F *h_MissingPcut[2]                   = {};
-  TH2F *h_MissingPvsMass[2]                = {};
+  TH2F *h_MissingPvsIMMass[2]                = {};
   TH2F *h_MissingMassvsSigmaMass          = NULL;
   TH2F *h_MissingPvsSigmaMass             = NULL;
 
@@ -131,10 +131,10 @@ public:
 
 void Histograms::DoHistograms(){
 
-  h_Vertex = new TH1F("h_Vertex","; Distancia [cm]; Conteo",200,0,-40);
+  h_Vertex = new TH1F("h_Vertex","; Distance [cm]; Frequency",200,0,-40);
 
-  h_Mass[0] = new TH1F("","; Masa [GeV/c^{2}]; Conteo",200,0,-1.5);
-  h_Mass[1] = new TH1F("","; Masa [GeV/c^{2}]; Conteo",200,0,-1.5);
+  h_Mass[0] = new TH1F("","; Mass [GeV/c^{2}]; Frequency",200,0,-1.5);
+  h_Mass[1] = new TH1F("","; Mass [GeV/c^{2}]; Frequency",200,0,-1.5);
   
   //------------------ Delta Beta ---------------//
   
@@ -144,7 +144,7 @@ void Histograms::DoHistograms(){
 
   
   h_BeVSp[0]=new TH2F("h_BeVSp_0"," ;p [GeV/c]; #beta;",200, 0, 3, 200, 0, 1);
-  h_BeVSp[1]=new TH2F("h_BeVSp_1"," ;p [GeV/c];#beta;",200, 0, 3, 200, 0, 1);
+  h_BeVSp[1]=new TH2F("h_BeVSp_1"," ;p [GeV/c]; #beta;",200, 0, 3, 200, 0, 1);
   h_BeVSp[2]=new TH2F("h_BeVSp_2"," ;p [GeV/c]; #beta;",200, 0, 3, 200, 0, 1);
 
   h_BeVSpT = new TH2F("h_BeVSpT"," ; p [GeV/c]; #beta;",200, 0, 3, 200, 0, 1);
@@ -186,9 +186,9 @@ void Histograms::DoHistograms(){
 
   //-----Correlation Theta-Phi, ----------//
 
-  h_ThePhi[0] = new TH2F("h_ThePhi_proton"," ; #phi #circ; #theta #circ;",200, -180, 180, 200, 0, 150);
-  h_ThePhi[1] = new TH2F("h_ThePhi_kaon"," ; #phi #circ;#theta #circ;",200,  -180, 180, 200, 0, 150);
-  h_ThePhi[2] = new TH2F("h_ThePhi_pion"," ; #phi #circ;#theta #circ;", 200,  -180, 180, 200, 0, 150);
+  h_ThePhi[0] = new TH2F("h_ThePhi_proton"," ; Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;",200, -180, 180, 200, 0, 150);
+  h_ThePhi[1] = new TH2F("h_ThePhi_kaon"," ; Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;",200,  -180, 180, 200, 0, 150);
+  h_ThePhi[2] = new TH2F("h_ThePhi_pion"," ; Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;", 200,  -180, 180, 200, 0, 150);
 
   F_ThePhiProt[0] = new TF1("F_ThePhiProt[0]","-1/(0.01*(TMath::Abs(x-180)-28))+10",150,180);
   F_ThePhiProt[1] = new TF1("F_ThePhiProt[0]","-1/(0.01*(TMath::Abs(x-120)-28))+10",90,150);
@@ -201,16 +201,16 @@ void Histograms::DoHistograms(){
   //-------------Fiducial cuts-------------------------//
 
   
-  h_ThePhicut[0] = new TH2F("h_ThePhi_protoncut"," ; #phi #circ;#theta #circ;",200, -180, 180, 200, 0, 150);
-  h_ThePhicut[1] = new TH2F("h_ThePhi_kaoncut"," ; #phi #circ;#theta #circ;",200,  -180, 180, 200, 0, 150);
-  h_ThePhicut[2] = new TH2F("h_ThePhi_pioncut"," ;  #phi #circ;#theta #circ;", 200,  -180, 180, 200, 0, 150);
+  h_ThePhicut[0] = new TH2F("h_ThePhi_protoncut"," ;  Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;",200, -180, 180, 200, 0, 150);
+  h_ThePhicut[1] = new TH2F("h_ThePhi_kaoncut"," ;  Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;",200,  -180, 180, 200, 0, 150);
+  h_ThePhicut[2] = new TH2F("h_ThePhi_pioncut"," ;   Azimuthal Angle  #phi #circ; Polar Angle  #theta #circ;", 200,  -180, 180, 200, 0, 150);
 
 
   
   //------------------ Photons, Delta T  ------------------ // 
   
-  h_DeltaTall[0]=new TH1F("h_DeltaTall_0"," ;#Delta t [ns];Conteo;", 200, -10, 10);
-  h_DeltaTall[1]=new TH1F("h_DeltaTall_1"," ;#Delta t [ns];Conteo;", 200, -10, 10);
+  h_DeltaTall[0]=new TH1F("h_DeltaTall_0"," ;#Delta t [ns];Frequency;", 200, -10, 10);
+  h_DeltaTall[1]=new TH1F("h_DeltaTall_1"," ;#Delta t [ns];Frequency;", 200, -10, 10);
 
 
   h_DeltaTallvsp[0]=new TH2F("h_DeltaTallvsp_0"," ;p [GeV/c];#Delta t [ns];", 200, 0, 3, 200, -10, 10);
@@ -218,17 +218,17 @@ void Histograms::DoHistograms(){
 
   //------------Delta T with Cuts ----------- //
   
-  h_DeltaT[0]=new TH1F("h_DeltaT_0"," ;#Delta t [ns];Conteo;", 200, -10, 10);
-  h_DeltaT[1]=new TH1F("h_DeltaT_1"," ;#Delta t [ns];Conteo;", 200, -10, 10);
+  h_DeltaT[0]=new TH1F("h_DeltaT_0"," ;#Delta t [ns];Frequency;", 200, -10, 10);
+  h_DeltaT[1]=new TH1F("h_DeltaT_1"," ;#Delta t [ns];Frequency;", 200, -10, 10);
 
   //--------------- Energy loss ----------- //
 
-  h_eloss[0]=new TH1F("h_eloss_0","; (P_{eloss}-P_{med})/P_{med};Conteo;",50, 0, 0.05);
-  h_eloss[1]=new TH1F("h_eloss_1","; (P_{eloss}-P_{med})/P_{med};Conteo;",50, 0, .05);
-  h_eloss[2]=new TH1F("h_eloss_2","; (P_{eloss}-P_{med})/P_{med};Conteo",50, 0, .05);
-  h_Celoss[0]=new TH2F("h_Celoss_0"," ;P_{med} GeV/c];(P_{eloss}-P_{med})/P_{med};", 200, 0, 2.5, 200, 0, 0.25);
-  h_Celoss[1]=new TH2F("h_Celoss_1"," ;P_{med} [GeV/c];(P_{eloss}-P_{med})/P_{med};", 200, 0, 3, 200, 0, 0.15);
-  h_Celoss[2]=new TH2F("h_Celoss_2"," ;P_{med} [GeV/c];(P_{eloss}-P_{med})/P_{med};", 200, 0, 2.5, 200, 0, 0.25);
+  h_eloss[0]=new TH1F("h_eloss_0","; (P_{eloss}-P_{meas})/P_{meas};Frequency;",50, 0, 0.05);
+  h_eloss[1]=new TH1F("h_eloss_1","; (P_{eloss}-P_{meas})/P_{meas};Frequency;",50, 0, .05);
+  h_eloss[2]=new TH1F("h_eloss_2","; (P_{eloss}-P_{meas})/P_{meas};Frequency",50, 0, .05);
+  h_Celoss[0]=new TH2F("h_Celoss_0"," ;P_{meas} [GeV/c];(P_{eloss}-P_{meas})/P_{meas};", 200, 0, 2.5, 200, 0, 0.25);
+  h_Celoss[1]=new TH2F("h_Celoss_1"," ;P_{meas} [GeV/c];(P_{eloss}-P_{meas})/P_{meas};", 200, 0, 3, 200, 0, 0.15);
+  h_Celoss[2]=new TH2F("h_Celoss_2"," ;P_{meas} [GeV/c];(P_{eloss}-P_{meas})/P_{meas};", 200, 0, 2.5, 200, 0, 0.25);
 
   //---- Get Coherent Edge ---- //
 
@@ -239,58 +239,56 @@ void Histograms::DoHistograms(){
   //-------------- Reconstruction --------- //
 
   h_MissingMass = new TH1F("h_missingmass",
-			   "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; Conteo",
+			   "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 			   100, 0.7, 1.2);
   
   h_MissingMass_kaonpion = new TH1F("h_missingmass_kaonpion",
-				    "; #gamma d #rightarrow #pi^{+} #pi^{-} X p [GeV/c^{2}]; Conteo",
+				    "; MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 				    100, 0.7, 1.2);
 
   h_MissingMasscut = new TH1F("h_missingmasscut",
-			      "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; Conteo",
+			      "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 			      100, 0.7, 1.2);
   
   h_MissingMass_kaonpioncut = new TH1F("h_missingmass_kaonpioncut",
-				       " ; #gamma d #rightarrow #pi^{+} #pi^{-} X p [GeV/c^{2}]; Conteo",
+				       " ; MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 				       100, 0.7, 1.2);
 
   
   h_MissingMass_vsMissingMasskaonpion[0] = new TH2F("MissingMass_correlation",
-						    "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}];  #gamma d #rightarrow #pi^{+} #pi^{-} X p [GeV/c^{2}]",
+						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]",
 						    100, 0.7, 1.2, 100, 0.7, 1.2);
 
   h_MissingMass_vsMissingMasskaonpion[1] = new TH2F("MissingMass_correlation_Cut",
-						    "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}];  #gamma d #rightarrow #pi^{+} #pi^{-} X p [GeV/c^{2}]",
+						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]",
 						    100, 0.7, 1.2, 100, 0.7, 1.2);
   
   h_MissingP[0] = new TH1F("h_missingpSigma",
-			   "; Missing momentum [GeV/c]; Conteo",
+			   "; Missing momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]; Frequency",
 			   100, 0.0, 1.);
   h_MissingP[1] = new TH1F("h_missingpLambda",
-			   "; Missing momentum [GeV/c]; Conteo",
+			   "; Missing momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]; Frequency",
 			   100, 0.0, 1.);
 
   h_MissingPcut[0] = new TH1F("h_missingpcutSigma",
-			      "; Missing momentum [GeV/c]; Conteo",
+			      "; Missing momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]; Frequency",
 			      100, 0.0, 1.5);
   h_MissingPcut[1] = new TH1F("h_missingpcutLambda",
-			      "; Missing momentum [GeV/c]; Conteo",
+			      "; Missing momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]; Frequency",
 			      100, 0.0, 1.5);
   
-
-
-
   
-  h_MissingPvsMass[0] = new TH2F("h_missingpvsmSigma",
-				 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; Missing Momentum (p) [GeV/c]",
+  h_MissingPvsIMMass[0] = new TH2F("h_missingpvsmSigma",
+				 "; IM(#pi^{-} n) [GeV/c^{2}]; Missing Momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]",
 				 100, 0.7, 1.2, 100, 0.0, 1.5);
 
-  h_MissingPvsMass[1] = new TH2F("h_missingpvsmLambda",
-				 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; Missing Momentum (p) [GeV/c]",
+  h_MissingPvsIMMass[1] = new TH2F("h_missingpvsmLambda",
+				 "; IM(#pi^{-} p) [GeV/c^{2}]; Missing Momentum (#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c]",
 				 100, 0.7, 1.2, 100, 0.0, 1.5);
 
 
   // ------- This aren't important -------- //
+  
   h_MissingMassvsSigmaMass = new TH2F("h_missingmvsSigma",
 				      "; Masa Invariante (#pi^{-} n) [GeV/c^{2}]; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]",
 				      100,1.0,1.5, 100, 0.7, 1.2);
@@ -302,42 +300,43 @@ void Histograms::DoHistograms(){
   // ----------------------------------- //
 
   h_InvariantMass = new TH1F("h_InvariantMass",
-			     "; Masa [GeV/c^{2}]; Conteo ",
+			     "; IM(#pi^{-} n) [GeV/c^{2}]; Frequency ",
 			     100, 1.0, 1.5);
   
   
   h_InvariantMasscut[0] = new TH1F("h_InvariantMasscut3Sig",
-				   "; Masa [GeV/c^{2}]; Conteo ",
+				   "; IM(#pi^{-} n) [GeV/c^{2}]; Frequency ",
 				   100, 1.0, 1.5);
 
   h_InvariantMasscut[1] = new TH1F("h_InvariantMasscut4Sig",
-				   "; Masa [GeV/c^{2}]; Conteo ",
+				   "; IM(#pi^{-} n) [GeV/c^{2}]; Frequency ",
 				   100, 1.0, 1.5);
 
   h_InvariantMasscut[2] = new TH1F("h_InvariantMasscut5Sig",
-				   "; Masa [GeV/c^{2}]; Conteo ",
+				   "; IM(#pi^{-} n) [GeV/c^{2}]; Frequency ",
 				   100, 1.0, 1.5);
   
   h_InvariantMasscut[3] = new TH1F("h_InvariantMasscut_ACP",
-				   "; Masa [GeV/c^{2}]; Conteo ",
+				   "; IM(#pi^{-} n) [GeV/c^{2}]; Frequency ",
 				   100, 1.0, 1.5);
 
   //----------Momentum proton---------------//
   
    h_MomentumProton = new TH1F("h_MomentumProton",
-			  "; Momentum [GeV/c]; Conteo ",
+			  "; Proton momentum [GeV/c]; Frequency ",
 			  100, 0, 2.0);
 
   
   //-------- Lambda and Lambda Fit ------ //
   
   h_LambdaMass = new TH1F("h_LambdaMass",
-			  "; Masa [GeV/c^{2}]; Conteo ",
+			  "; IM(#pi^{-} p) [GeV/c^{2}]; Frequency ",
 			  100, 1.08, 1.16);
 
   lamdaMassFit = new TF1("lamdaMassFit","gaus",1.08,1.16);
   
-  //----------------------------------//
+  //--------- Others --------------//
+  
   h_DeltaBVSInvariantMass = new TH2F("h_DeltaBVSInvariantMass",
 				     "",
 				     100,0, 2,100,-0.17, 0.17);
@@ -350,14 +349,17 @@ void Histograms::DoHistograms(){
 				       "",
 				       100,0, 1.5,100,-0.17, 0.17);
 
+
   //--------------Correlation Invariant masses (Lambda vs Sigma)----//
+
   h_InvMassLambda_vsInvMassSigma = new TH2F("h_InvMassLambda_vsInvMassSigma",
-				      "; Invariant mass (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
+				      "; IM(#pi^{-} n) [GeV/c^{2}]; IM(#pi^{-} p) [GeV/c^{2}]",
 				      200,1.06,1.4, 200, 1.0, 1.5);
 
-   //--------------Correlation momentums (Lambda vs Sigma)----//
+  //--------------Correlation momentums (Lambda vs Sigma)----//
+
   h_CorrelationMMomentum  = new TH2F("h_CorrelationMMomentum",
-				     "; Missing momentum [GeV/c^{2}]; Missing momentum [GeV/c^{2}] [GeV/c^{2}]",
+				     "; IM(#pi^{-} n) momentum [GeV/c^{2}]; IM(#pi^{-} p) momentum [GeV/c^{2}] [GeV/c^{2}]",
 				     200,0, 1.6 , 200, 0, 1.6);
 
 
@@ -365,25 +367,25 @@ void Histograms::DoHistograms(){
   
   //---------------Missing mass Sigma-----------------------------//
   h_MMassSigma = new TH1F("h_MMassSigma",
-				   "; Missing mass sigma  (#pi^{-} n) [GeV/c^{2}]; Conteo ",
+				   "; MM(#gamma d #rightarrow K^{+} X p) [GeV/c^{2}]; Frequency ",
 				   100, 0.95, 1.45);
 
   //--------Missing mass Sigma cut--------------//
   h_MMassSigmaCut = new TH1F("h_MMassSigmaCut",
-				   "; Missing mass sigma cut  (#pi^{-} n) [GeV/c^{2}]; Conteo ",
+				   "; MM(#gamma d #rightarrow K^{+} X p) [GeV/c^{2}]; Frequency ",
 				   100, 0.95, 1.45);
   
   
   //--------------Correlation MM neutron and Missing mass Sigma----//
   
   h_MMNeutron_vsMMassSigma[0] = new TH2F("h_MMNeutron_vsMMassSigma",
-					 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; #gamma d #rightarrow K^{+} X p [GeV/c^{2}]",
+					 "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; MM(#gamma d #rightarrow K^{+} X p) [GeV/c^{2}]",
 					 200, 0.6, 1.5,200,1,1.4);
  
 
 
   h_MMNeutron_vsMMassSigma[1] = new TH2F("h_MMNeutron_vsMMassSigmaC",
-					 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; #gamma d #rightarrow K^{+} X p [GeV/c^{2}]",
+					 "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; MM(#gamma d #rightarrow K^{+} X p) [GeV/c^{2}]",
 					 200, 0.6, 1.5,200,1,1.4);
  
 
@@ -946,15 +948,15 @@ void Histograms::DoCanvas(){
   TCanvas *c312=new TCanvas("c312","Missing Momentum vs Missing Mass", 1450, 500);
   c312->Divide(2,1);
   c312->cd(1);
-  h_MissingPvsMass[0]->SetLabelSize(0.05, "XY");
-  h_MissingPvsMass[0]->SetTitleSize(0.045, "XY");
-  h_MissingPvsMass[0]->Draw("colz");
+  h_MissingPvsIMMass[0]->SetLabelSize(0.05, "XY");
+  h_MissingPvsIMMass[0]->SetTitleSize(0.045, "XY");
+  h_MissingPvsIMMass[0]->Draw("colz");
   
 
   c312->cd(2);
-  h_MissingPvsMass[1]->SetLabelSize(0.05, "XY");
-  h_MissingPvsMass[1]->SetTitleSize(0.045, "XY");
-  h_MissingPvsMass[1]->Draw("colz");
+  h_MissingPvsIMMass[1]->SetLabelSize(0.05, "XY");
+  h_MissingPvsIMMass[1]->SetTitleSize(0.045, "XY");
+  h_MissingPvsIMMass[1]->Draw("colz");
   
   c312->SaveAs("imagenes/MissingMomentumCorrelation.eps");
 
@@ -963,7 +965,7 @@ void Histograms::DoCanvas(){
 
   //------ Lambda -------//
   
-  TCanvas *STDC = new TCanvas("STDC","Invariant mass", 900, 500);
+  TCanvas *STDC = new TCanvas("STDC","Invariant mass", 1450, 500);
   STDC->cd(1);
   h_LambdaMass->SetLabelSize(0.045, "XY");
   h_LambdaMass->SetTitleSize(0.043, "XY");
@@ -1058,7 +1060,7 @@ void Histograms::DoCanvas(){
   h_MMassSigmaCut->SetTitleSize(0.045, "XY");  
   h_MMassSigmaCut->Draw();
   
-  cMMS->SaveAs("imagenes/MissingMassSigmaCut.eps");
+  cMMSC->SaveAs("imagenes/MissingMassSigmaCut.eps");
 
   
   //--------------Correlation Invariant mass (Lambda) vs Missing Mass Sigma----//

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -81,10 +81,14 @@ protected:
 
   //------Missing mass Sigma--------//
   TH1F *h_MMassSigma                       = NULL;
+  TH1F *h_MMassSigmaCut                    = NULL;
   
   //--Correlations between Invariant and missing mass (lambda and sigma)--//
   TH2F *h_InvMassLambda_vsInvMassSigma    = NULL;
   TH2F *h_InvMassLambda_vsMMassSigma      = NULL;
+
+  //-----Correlation Momentums (lambda and Sigma)----//
+  TH2F *h_CorrelationMMomentum            = NULL;
   
   //--- Ellipse Cuts ---- //
   
@@ -100,8 +104,10 @@ protected:
   TH2F *h_ThePhicut[3]                      = {};
   
   //----Costheta-Kaon Boost-------------------//
-  TH1F *h_KCosThetaCM                     = NULL;
+  TH1F *h_KCosThetaCM                      = NULL;
 
+  //-------Momentum proton------------------//
+  TH1F *h_MomentumProton                    = NULL;
   //-----Kaon phi-------------------//
   TH1F *h_kaonPhiPA[2]                      = {};
   TH1F *h_kaonPhiPE[2]                      = {};
@@ -314,6 +320,13 @@ void Histograms::DoHistograms(){
   h_InvariantMasscut[3] = new TH1F("h_InvariantMasscut_ACP",
 				   "; Masa [GeV/c^{2}]; Conteo ",
 				   100, 1.0, 1.5);
+
+  //----------Momentum proton---------------//
+  
+   h_MomentumProton = new TH1F("h_MomentumProton",
+			  "; Momentum [GeV/c]; Conteo ",
+			  100, 0, 2.0);
+
   
   //-------- Lambda and Lambda Fit ------ //
   
@@ -341,18 +354,30 @@ void Histograms::DoHistograms(){
 				      "; Invariant mass (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
 				      200,1.06,1.4, 200, 1.0, 1.5);
 
+   //--------------Correlation momentums (Lambda vs Sigma)----//
+  h_CorrelationMMomentum  = new TH2F("h_CorrelationMMomentum",
+				     "; Missing momentum [GeV/c^{2}]; Missing momentum [GeV/c^{2}] [GeV/c^{2}]",
+				     200,0, 1.6 , 200, 0, 1.6);
+
+
+
+  
   //---------------Missing mass Sigma-----------------------------//
   h_MMassSigma = new TH1F("h_MMassSigma",
 				   "; Missing mass sigma  (#pi^{-} n) [GeV/c^{2}]; Conteo ",
 				   100, 0.95, 1.45);
 
+  //--------Missing mass Sigma cut--------------//
+  h_MMassSigmaCut = new TH1F("h_MMassSigmaCut",
+				   "; Missing mass sigma cut  (#pi^{-} n) [GeV/c^{2}]; Conteo ",
+				   100, 0.95, 1.45);
+  
   
   //--------------Correlation Invariant mass (Lambda) and Missing mass Sigma----//
   h_InvMassLambda_vsMMassSigma = new TH2F("h_InvMassLambda_vsMMassSigma",
 				      "; Missing mass Sigma (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
 				      200,1.06,1.4, 200, 1.0, 1.5);
  
-
 
   //myEllipse = new TEllipse(offsetx,offsety,radx,rady,0,360,70);
 
@@ -935,7 +960,7 @@ void Histograms::DoCanvas(){
   h_LambdaMass->SetTitleSize(0.043, "XY");
   h_LambdaMass->Draw();
   TLine *LambdaLines[2]={};
-  LambdaLines[0] = new TLine(1.11, h_LambdaMass->GetMaximum(),1.11,0);
+  LambdaLines[0] = new TLine(1.1, h_LambdaMass->GetMaximum(),1.1,0);
   LambdaLines[1] = new TLine(1.132, h_LambdaMass->GetMaximum(),1.132,0);
 
   LambdaLines[0]->SetLineWidth(2);
@@ -979,6 +1004,16 @@ void Histograms::DoCanvas(){
  
   
   IVM->SaveAs("imagenes/InvariantMassComparation_Sigma.eps");
+
+  //-------------Momentum proton--------------//
+  TCanvas *cMP=new TCanvas("cMP","Momentum proton", 900, 500);
+  cMP->cd(1);
+  h_MomentumProton->SetTitleSize(0.045, "XY");  
+  h_MomentumProton->Draw();
+  
+  cMP->SaveAs("imagenes/MomentumProton.eps");
+
+
   
   //--------------Correlation Invariant masses (Lambda vs Sigma)----//
   TCanvas *cIMLS=new TCanvas("cIMLS","Correlation of Invariant masses", 900, 500);
@@ -987,6 +1022,15 @@ void Histograms::DoCanvas(){
   h_InvMassLambda_vsInvMassSigma->Draw("colz");
   
   cIMLS->SaveAs("imagenes/InvariantMassCorrelation.eps");
+
+  //--------------Correlation Missing momentums--------------------//
+
+   TCanvas *cMMom=new TCanvas("cMMom","Correlation Missing momentums", 900, 500);
+  cMMom->cd(1);
+  h_CorrelationMMomentum->SetTitleSize(0.045, "XY");  
+  h_CorrelationMMomentum->Draw("colz");
+  
+  cMMom->SaveAs("imagenes/CorrelationMissingMomentums.eps");
   
   
   //---------------Missing mass Sigma-----------------------//
@@ -997,6 +1041,16 @@ void Histograms::DoCanvas(){
   h_MMassSigma->Draw();
   
   cMMS->SaveAs("imagenes/MissingMassSigma.eps");
+
+ //---------------Missing mass Sigma Cut-----------------------//
+  
+  TCanvas *cMMSC=new TCanvas("cMMSC","Missing mass Sigma Cut", 900, 500);
+  cMMSC->cd(1);
+  h_MMassSigmaCut->SetTitleSize(0.045, "XY");  
+  h_MMassSigmaCut->Draw();
+  
+  cMMS->SaveAs("imagenes/MissingMassSigmaCut.eps");
+
   
   //--------------Correlation Invariant mass (Lambda) vs Missing Mass Sigma----//
   TCanvas *cIMMM=new TCanvas("cIMMM","Correlation Invariant mass (lambda) vs Missing Mass Sigma", 900, 500);
@@ -1005,12 +1059,6 @@ void Histograms::DoCanvas(){
   h_InvMassLambda_vsMMassSigma->Draw("colz");
   
    cIMMM->SaveAs("imagenes/InvariantMassMMSigmaCorrelation.eps");
-
-  
-
-
-
-  
 
   //------------ Final Invarian Mass ---------------//
   

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -84,7 +84,7 @@ protected:
   
   //--Correlations between Invariant and missing mass (lambda and sigma)--//
   TH2F *h_InvMassLambda_vsInvMassSigma    = NULL;
-  TH2F *h_InvMassLambda_vsMMassSigma      = NULL;
+  TH2F *h_MMNeutron_vsMMassSigma[2]       = {};
   
   //--- Ellipse Cuts ---- //
   
@@ -347,12 +347,17 @@ void Histograms::DoHistograms(){
 				   100, 0.95, 1.45);
 
   
-  //--------------Correlation Invariant mass (Lambda) and Missing mass Sigma----//
-  h_InvMassLambda_vsMMassSigma = new TH2F("h_InvMassLambda_vsMMassSigma",
-				      "; Missing mass Sigma (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
-				      200,1.06,1.4, 200, 1.0, 1.5);
+  //--------------Correlation MM neutron and Missing mass Sigma----//
+  
+  h_MMNeutron_vsMMassSigma[0] = new TH2F("h_MMNeutron_vsMMassSigma",
+					 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; #gamma d #rightarrow K^{+} X p [GeV/c^{2}]",
+					 200, 0.6, 1.5,200,1,1.4);
  
 
+  h_MMNeutron_vsMMassSigma[1] = new TH2F("h_MMNeutron_vsMMassSigmaC",
+					 "; #gamma d #rightarrow K^{+} #pi^{-} X p [GeV/c^{2}]; #gamma d #rightarrow K^{+} X p [GeV/c^{2}]",
+					 200, 0.6, 1.5,200,1,1.4);
+ 
 
   //myEllipse = new TEllipse(offsetx,offsety,radx,rady,0,360,70);
 
@@ -1001,16 +1006,19 @@ void Histograms::DoCanvas(){
   //--------------Correlation Invariant mass (Lambda) vs Missing Mass Sigma----//
   TCanvas *cIMMM=new TCanvas("cIMMM","Correlation Invariant mass (lambda) vs Missing Mass Sigma", 900, 500);
   cIMMM->cd(1);
-  h_InvMassLambda_vsMMassSigma->SetTitleSize(0.045, "XY");  
-  h_InvMassLambda_vsMMassSigma->Draw("colz");
+  h_MMNeutron_vsMMassSigma[0]->SetTitleSize(0.045, "XY");  
+  h_MMNeutron_vsMMassSigma[0]->Draw("colz");
   
-   cIMMM->SaveAs("imagenes/InvariantMassMMSigmaCorrelation.eps");
+  cIMMM->SaveAs("imagenes/InvariantMassMMSigmaCorrelation.eps");
 
+  TCanvas *cIMMMC=new TCanvas("cIMMMC","Correlation Invariant mass (lambda) vs Missing Mass Sigma", 900, 500);
+  cIMMMC->cd(1);
+  h_MMNeutron_vsMMassSigma[1]->SetTitleSize(0.045, "XY");  
+  h_MMNeutron_vsMMassSigma[1]->Draw("colz");
   
+  cIMMMC->SaveAs("imagenes/InvariantMassMMSigmaCorrelation_C.eps");
 
-
-
-  
+ 
 
   //------------ Final Invarian Mass ---------------//
   

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -79,10 +79,17 @@ protected:
   TH2F *h_DeltaBVSMissingMass             = NULL;
   TH2F *h_DeltaBVSMissingMomentum         = NULL;
 
+  //------Missing mass Sigma--------//
+  TH1F *h_MMassSigma                       = NULL;
+  
+  //--Correlations between Invariant and missing mass (lambda and sigma)--//
+  TH2F *h_InvMassLambda_vsInvMassSigma    = NULL;
+  TH2F *h_InvMassLambda_vsMMassSigma      = NULL;
+  
   //--- Ellipse Cuts ---- //
   
-  TEllipse *myEllipse                     = NULL;
-  double radx=0.034, rady=0.02, offsetx=0.937, offsety=1.047, angle=70*TMath::DegToRad();
+  // TEllipse *myEllipse                     = NULL;
+  //double radx=0.034, rady=0.02, offsetx=0.937, offsety=1.047, angle=70*TMath::DegToRad();
   
   //-----Correlation Theta-Phi, ----------//
  
@@ -329,8 +336,25 @@ void Histograms::DoHistograms(){
 				       "",
 				       100,0, 1.5,100,-0.17, 0.17);
 
+  //--------------Correlation Invariant masses (Lambda vs Sigma)----//
+  h_InvMassLambda_vsInvMassSigma = new TH2F("h_InvMassLambda_vsInvMassSigma",
+				      "; Invariant mass (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
+				      200,1.06,1.4, 200, 1.0, 1.5);
 
-  myEllipse = new TEllipse(offsetx,offsety,radx,rady,0,360,70);
+  //---------------Missing mass Sigma-----------------------------//
+  h_MMassSigma = new TH1F("h_MMassSigma",
+				   "; Missing mass sigma  (#pi^{-} n) [GeV/c^{2}]; Conteo ",
+				   100, 0.95, 1.45);
+
+  
+  //--------------Correlation Invariant mass (Lambda) and Missing mass Sigma----//
+  h_InvMassLambda_vsMMassSigma = new TH2F("h_InvMassLambda_vsMMassSigma",
+				      "; Missing mass Sigma (#pi^{-} n) [GeV/c^{2}]; Invariant mass (#pi^{-} p) [GeV/c^{2}]",
+				      200,1.06,1.4, 200, 1.0, 1.5);
+ 
+
+
+  //myEllipse = new TEllipse(offsetx,offsety,radx,rady,0,360,70);
 
 
   //--------------KaonCosTheta Boost-------------//
@@ -789,9 +813,15 @@ void Histograms::DoCanvas(){
   c0ELL->cd(1);
   h_MissingMass_vsMissingMasskaonpion[0]->SetTitleSize(0.045, "XY");  
   h_MissingMass_vsMissingMasskaonpion[0]->Draw("colz");
-  myEllipse->SetFillStyle(0);
-  myEllipse->SetLineColor(kRed);
-  myEllipse->Draw("same");
+  TLine *MMCorrLine;
+  MMCorrLine = new TLine(0.7, 0.98,1.2, 0.98);
+  MMCorrLine->SetLineWidth(2);
+  MMCorrLine->SetLineColor(2);
+  MMCorrLine->Draw("same");
+  
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
   c0ELL->SaveAs("imagenes/Ellipse.eps");
 
   //---------- MM Correlation with cut ---------------//
@@ -800,9 +830,9 @@ void Histograms::DoCanvas(){
   c0ELLC->cd(1);
   h_MissingMass_vsMissingMasskaonpion[1]->SetTitleSize(0.045, "XY");  
   h_MissingMass_vsMissingMasskaonpion[1]->Draw("colz");
-  myEllipse->SetFillStyle(0);
-  myEllipse->SetLineColor(kRed);
-  myEllipse->Draw("same");
+  //myEllipse->SetFillStyle(0);
+  //myEllipse->SetLineColor(kRed);
+  //myEllipse->Draw("same");
   c0ELLC->SaveAs("imagenes/Ellipse_C.eps");
 
   //----------- MM After Cuts for MM correlation ------- //
@@ -904,6 +934,18 @@ void Histograms::DoCanvas(){
   h_LambdaMass->SetLabelSize(0.045, "XY");
   h_LambdaMass->SetTitleSize(0.043, "XY");
   h_LambdaMass->Draw();
+  TLine *LambdaLines[2]={};
+  LambdaLines[0] = new TLine(1.11, h_LambdaMass->GetMaximum(),1.11,0);
+  LambdaLines[1] = new TLine(1.132, h_LambdaMass->GetMaximum(),1.132,0);
+
+  LambdaLines[0]->SetLineWidth(2);
+  LambdaLines[1]->SetLineWidth(2);
+  LambdaLines[0]->SetLineColor(3);
+  LambdaLines[1]->SetLineColor(3);
+
+  LambdaLines[0]->Draw("same");
+  LambdaLines[1]->Draw("same");
+  
   h_LambdaMass->Fit(lamdaMassFit);
   gStyle->SetOptFit(111);
   lamdaMassFit->Draw("same");
@@ -937,6 +979,38 @@ void Histograms::DoCanvas(){
  
   
   IVM->SaveAs("imagenes/InvariantMassComparation_Sigma.eps");
+  
+  //--------------Correlation Invariant masses (Lambda vs Sigma)----//
+  TCanvas *cIMLS=new TCanvas("cIMLS","Correlation of Invariant masses", 900, 500);
+  cIMLS->cd(1);
+  h_InvMassLambda_vsInvMassSigma->SetTitleSize(0.045, "XY");  
+  h_InvMassLambda_vsInvMassSigma->Draw("colz");
+  
+  cIMLS->SaveAs("imagenes/InvariantMassCorrelation.eps");
+  
+  
+  //---------------Missing mass Sigma-----------------------//
+  
+  TCanvas *cMMS=new TCanvas("cMMS","Missing mass Sigma", 900, 500);
+  cMMS->cd(1);
+  h_MMassSigma->SetTitleSize(0.045, "XY");  
+  h_MMassSigma->Draw();
+  
+  cMMS->SaveAs("imagenes/MissingMassSigma.eps");
+  
+  //--------------Correlation Invariant mass (Lambda) vs Missing Mass Sigma----//
+  TCanvas *cIMMM=new TCanvas("cIMMM","Correlation Invariant mass (lambda) vs Missing Mass Sigma", 900, 500);
+  cIMMM->cd(1);
+  h_InvMassLambda_vsMMassSigma->SetTitleSize(0.045, "XY");  
+  h_InvMassLambda_vsMMassSigma->Draw("colz");
+  
+   cIMMM->SaveAs("imagenes/InvariantMassMMSigmaCorrelation.eps");
+
+  
+
+
+
+  
 
   //------------ Final Invarian Mass ---------------//
   

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -277,7 +277,7 @@ void Histograms::DoHistograms(){
   h_MissingMass_vsMissingMasspionkaon[0] = new TH2F("MissingMass_correlationPionKaon",
 						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow K^{+} K^{-} X p) [GeV/c^{2}]",
 						      300, 0.7, 1.2, 300, 0, 1.2);
-  h_MissingMass_vsMissingMasspionkaon[0] = new TH2F("MissingMass_correlationPionKaon_Cut",
+  h_MissingMass_vsMissingMasspionkaon[1] = new TH2F("MissingMass_correlationPionKaon_Cut",
 						    "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}];  MM(#gamma d #rightarrow K^{+} K^{-} X p) [GeV/c^{2}]",
 						      300, 0.7, 1.2, 300, 0, 1.2);
 

--- a/CodeCuts/Histograms.h
+++ b/CodeCuts/Histograms.h
@@ -2,7 +2,8 @@
 #define HISTOGRAMS_C
 
 #include "include/Libraries.h"
-#include "src/TPaveStateModify.C"
+#include "include/MaxLike.h"
+#include "include/TPaveStateModify.h"
 
 using namespace std;
 
@@ -20,111 +21,114 @@ class Histograms{
   
 protected:
 
-  TH1F *h_Vertex                            = NULL;
+  TH1F *h_Vertex                            		= NULL;
 
-  TH1F *h_Mass[2]                           = {};
+  TH1F *h_Mass[2]                           		= {};
   
-  TH2F *h_DeltaBe[3]                        = {};
-  TH2F *h_BeVSp[3]                          = {};
-  TH2F *h_BeVSpT                            = NULL;
-  TH2F *h_DeltaBecut[3]                     = {};
-  TH2F *h_BeVSpcut[3]                       = {};
+  TH2F *h_DeltaBe[3]                        		= {};
+  TH2F *h_BeVSp[3]                          		= {};
+  TH2F *h_BeVSpT                            		= NULL;
+  TH2F *h_DeltaBecut[3]                     		= {};
+  TH2F *h_BeVSpcut[3]                       		= {};
   
   
-  TF1 *FFits[3]                             = {};               //Fits for do cuts
-  TF1 *FFitsminus[3]                        = {};
-  string FFname[3]                          = {};
+  TF1 *FFits[3]                             		= {};               //Fits for do cuts
+  TF1 *FFitsminus[3]                        		= {};
+  string FFname[3]                          		= {};
   
-  TH1F *h_DeltaTall[2]                      = {};
-  TH2F *h_DeltaTallvsp[2]                   = {};
-  TH1F *h_DeltaT[2]                         = {};
-  TH1F *h_eloss[3]                          = {};
-  TH2F *h_Celoss[3]                         = {};
+  TH1F *h_DeltaTall[2]                      		= {};
+  TH2F *h_DeltaTallvsp[2]                  		= {};
+  TH1F *h_DeltaT[2]                         		= {};
+  TH1F *h_eloss[3]                          		= {};
+  TH2F *h_Celoss[3]                         		= {};
   
   //--> Beta vs P with PDG MASSES  
 
-  TF1 *BeVSp[3]                             = {};
+  TF1 *BeVSp[3]                             		= {};
 
 
   //---- Get Coherent Edge ---- //
 
-  TH1F *h_TagrEpho[3]                       = {};
+  TH1F *h_TagrEpho[3]                       		= {};
   
   //---- Missing mass ----//
   
-  TH1F *h_MissingMass                     = NULL;
-  TH1F *h_MissingMass_kaonpion            = NULL;
-  TH1F *h_MissingMasscut                  = NULL;
-  TH1F *h_MissingMass_kaonpioncut         = NULL;
+  TH1F *h_MissingMass              		       	= NULL;
+  TH1F *h_MissingMasscut                  		= NULL;
+  TH1F *h_MissingMass_kaonpioncut         		= NULL;
   
   TH2F *h_MissingMass_vsMissingMasskaonpion[2] 		= {};
   TH2F *h_MissingMass_vsMissingMasskaonproton[2] 	= {};
   TH2F *h_MissingMass_vsMissingMasspionkaon[2] 		= {};
 
-  TH1F *h_MissingP[2]                      = {};
-  TH1F *h_MissingPcut[2]                   = {};
-  TH2F *h_MissingPvsIMMass[2]                = {};
-  TH2F *h_MissingMassvsSigmaMass          = NULL;
-  TH2F *h_MissingPvsSigmaMass             = NULL;
+  TH1F *h_MissingMass_kaonpion            		= NULL;
+  TH1F *h_MissingMass_kaonproton 			= NULL;
+  TH1F *h_MissingMass_pionkaon	 			= NULL;
 
-  TH1F *h_InvariantMass                   = NULL;
-  TH1F *h_InvariantMasscut[4]                = {};
+  TH1F *h_MissingP[2]                      		= {};
+  TH1F *h_MissingPcut[2]                   		= {};
+  TH2F *h_MissingPvsIMMass[2]                		= {};
+  TH2F *h_MissingMassvsSigmaMass          		= NULL;
+  TH2F *h_MissingPvsSigmaMass             		= NULL;
+
+  TH1F *h_InvariantMass                   		= NULL;
+  TH1F *h_InvariantMasscut[4]                		= {};
 
   //---- Lambda and Lambda Fit ---- //
   
-  TH1F *h_LambdaMass                      = NULL;
-  TF1 *lamdaMassFit                       = NULL; 
+  TH1F *h_LambdaMass                      		= NULL;
+  TF1 *lamdaMassFit                       		= NULL; 
   
   
-  TH2F *h_DeltaBVSInvariantMass           = NULL;
-  TH2F *h_DeltaBVSMissingMass             = NULL;
-  TH2F *h_DeltaBVSMissingMomentum         = NULL;
+  TH2F *h_DeltaBVSInvariantMass           		= NULL;
+  TH2F *h_DeltaBVSMissingMass             		= NULL;
+  TH2F *h_DeltaBVSMissingMomentum         		= NULL;
 
   //------Missing mass Sigma--------//
-  TH1F *h_MMassSigma                       = NULL;
-  TH1F *h_MMassSigmaCut                    = NULL;
+  TH1F *h_MMassSigma                       		= NULL;
+  TH1F *h_MMassSigmaCut                    		= NULL;
   
   //--Correlations between Invariant and missing mass (lambda and sigma)--//
-  TH2F *h_InvMassLambda_vsInvMassSigma    = NULL;
-  TH2F *h_MMNeutron_vsMMassSigma[2]       = {};
+  TH2F *h_InvMassLambda_vsInvMassSigma    		= NULL;
+  TH2F *h_MMNeutron_vsMMassSigma[2]       		= {};
   
   //-----Correlation Momentums (lambda and Sigma)----//
-  TH2F *h_CorrelationMMomentum            = NULL;
+  TH2F *h_CorrelationMMomentum            		= NULL;
   
 
   //--- Ellipse Cuts ---- //
   
-  TEllipse *myEllipse                     = NULL;
+  TEllipse *myEllipse                     		= NULL;
   double radx=0.1569373, rady=0.03295391, offsetx=0.5972416, offsety=1.153089-0.02, angle=360*TMath::DegToRad();
   double radx1=0.12744, rady1=0.01959062, offsetx1=1.152367, offsety1=1.199867, angle1=360*TMath::DegToRad();
   //-----Correlation Theta-Phi, ----------//
  
-  TH2F *h_ThePhi[3]                         = {};
-  TF1 *F_ThePhiProt[7]                      = {};
+  TH2F *h_ThePhi[3]                         		= {};
+  TF1 *F_ThePhiProt[7]                      		= {};
   
   //--- Fiduciary cuts ---//
-  TH2F *h_ThePhicut[3]                      = {};
+  TH2F *h_ThePhicut[3]                      		= {};
   
   //----Costheta-Kaon Boost-------------------//
-  TH1F *h_KCosThetaCM                      = NULL;
+  TH1F *h_KCosThetaCM                      		= NULL;
 
   //-------Momentum proton------------------//
-  TH1F *h_MomentumProton                    = NULL;
-  TH2F *h_CorrIvan[3]                       = {};
-  TH1F *h_CorrIvanM			    = NULL; 
+  TH1F *h_MomentumProton                    		= NULL;
+  TH2F *h_CorrIvan[3]                       		= {};
+  TH1F *h_CorrIvanM			   		= NULL; 
   
   //-----Kaon phi-------------------//
-  TH1F *h_kaonPhiPA[2]                      = {};
-  TH1F *h_kaonPhiPE[2]                      = {};
+  TH1F *h_kaonPhiPA[2]                      		= {};
+  TH1F *h_kaonPhiPE[2]                      		= {};
     
   //---------Function to do asymmetry fit----//
   
   vector<vector<double> > MEASPhi{2}; //2 is the number of binning
   vector<vector<double> > MEASGammaP{2};
     
-  TF1 *FuncAsym                             = NULL;
-  TH1F *h_Asym[2]                           = {};
-
+  TF1 *FuncAsym                             		= NULL;
+  TH1F *h_Asym[2]                           		= {};
+  TF2 *Like[2] 				    		= {};
    
 public:
   Histograms(){}
@@ -245,11 +249,22 @@ void Histograms::DoHistograms(){
   h_MissingMass = new TH1F("h_missingmass",
 			   "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 			   100, 0.7, 1.2);
+
+  // ---- MIS-identification ----/
   
   h_MissingMass_kaonpion = new TH1F("h_missingmass_kaonpion",
 				    "; MM(#gamma d #rightarrow #pi^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 				    100, 0.7, 1.2);
 
+  h_MissingMass_kaonproton = new TH1F("h_missingmass_kaonproton",
+				    "; MM(#gamma d #rightarrow p #pi^{-} X p) [GeV/c^{2}]; Frequency",
+				    100, 0, 1.2);
+
+  h_MissingMass_pionkaon = new TH1F("h_missingmass_pionkaon",
+				    "; MM(#gamma d #rightarrow K^{+} K^{-} X p) [GeV/c^{2}]; Frequency",
+				    100, 0, 1.2);
+
+  
   h_MissingMasscut = new TH1F("h_missingmasscut",
 			      "; MM(#gamma d #rightarrow K^{+} #pi^{-} X p) [GeV/c^{2}]; Frequency",
 			      100, 0.7, 1.2);
@@ -434,6 +449,7 @@ void Histograms::DoHistograms(){
   
   h_Asym[0] = new TH1F("h_Asym[0]","Asymmetry first partition", 100, -180, 180);
   h_Asym[1] = new TH1F("h_Asym[1]","Asymmetry Second partition",100, -180, 180);
+
 }
 
 
@@ -971,7 +987,7 @@ void Histograms::DoCanvas(){
 
   c0MMC->SaveAs("imagenes/MissingMass_Kaon.eps");
   
-  //------ Pion + ------//
+  //------ MIS-identification ---//
 
   gStyle->SetOptStat("me");
    
@@ -991,6 +1007,19 @@ void Histograms::DoCanvas(){
 
   c1MMC->SaveAs("imagenes/MissingMass_Pion.eps");
 
+  TCanvas *c2MM=new TCanvas("c2MM","Missing mass", 1200, 500);
+  c2MM->cd(1);
+  h_MissingMass_kaonproton->Draw();
+
+  c2MM->SaveAs("imagenes/MissingMass_Proton.eps");
+
+  TCanvas *c3MM=new TCanvas("c3MM","Missing mass", 1200, 500);
+  c3MM->cd(1);
+  h_MissingMass_pionkaon->Draw();
+
+  c3MM->SaveAs("imagenes/MissingMass_PionK.eps");
+  
+  
   //------------ Missing Momentum -----------------//
   
   TCanvas *MMP=new TCanvas("MMP","Missing Momentum", 1450, 500);
@@ -1276,18 +1305,31 @@ void Histograms::DoCanvas(){
     MaxLike Min(MEASPhi.at(i), MEASGammaP.at(i));
     ROOT::Math::Functor f(Min,2);
     minim->SetFunction(f);
-    minim->SetVariable(0, "Sigma", 0, 0.01);
-    minim->SetVariable(1, "Phi", 0, 0.01);
+    minim->SetVariable(0, "Sigma", 1, 0.001);
+    minim->SetVariable(1, "Phi", 1, 0.001);
+    // minim->SetVariableLimits(0,0,2);
     minim->SetPrintLevel(1);
     minim->Minimize();
 
     const double *xs = minim->X();
     std::cout << "minim: f(" << xs[0] << "," << xs[1] <<"): "
 	      << minim->MinValue()  << std::endl;
-  }
 
+    
+    MaxLikeTF MinF(MEASPhi.at(i),MEASGammaP.at(i));
+    Like[i] = new TF2("",MinF,-1.5,1.5,-15,15,0);
+    
+  }
+  
   c44->SaveAs("imagenes/Asymmetry.eps");
-   
+
+  TCanvas *cMin = new TCanvas("","",900,450);
+  cMin->Divide(2,1);
+  cMin->cd(1);
+  Like[0]->Draw("colz");
+  cMin->cd(2);
+  Like[1]->Draw("colz");
+  cMin->SaveAs("imagenes/Like.eps");
 }
 
 
@@ -1421,7 +1463,7 @@ vector<double> HistoBinning(TH1 *PrincipalHisto,
 Double_t fitf(Double_t *x, Double_t *par){
   double num=0, denom=0;
   num=par[0]-1.0-(par[0]*par[1]+1.0)/(par[1]+1.0)*2*par[2]*par[3]*TMath::Cos(2*x[0]*TMath::DegToRad());
-  denom=par[0]+1.0-   (par[0]*par[1]-1.0)/(par[1]+1.0)*2*par[2]*par[3]*TMath::Cos(2*x[0]*TMath::DegToRad());
+  denom=par[0]+1.0-(par[0]*par[1]-1.0)/(par[1]+1.0)*2*par[2]*par[3]*TMath::Cos(2*x[0]*TMath::DegToRad());
   Double_t fitval =num/denom;
   return fitval;
 }

--- a/CodeCuts/include/DataEvent.h
+++ b/CodeCuts/include/DataEvent.h
@@ -1,19 +1,13 @@
 #ifndef DATAEVENT_H
 #define DATAEVENT_H
 
+#include "Libraries.h"
+
 #pragma link C++ class vector<TLorentzVector>+;
 #pragma link C++ class vector<TVector3>+;
 
-
-#include <iostream>
-#include <vector>
-#include "TVector3.h"
-#include "TLorentzVector.h"
-#include "TFile.h"
-#include <TChain.h>
-#include <fstream>
-
 using namespace std;
+
 class DataEvent{
 
 

--- a/CodeCuts/include/Libraries.h
+++ b/CodeCuts/include/Libraries.h
@@ -1,9 +1,5 @@
-#ifndef LIBRARIES_H
-#define LIBRARIES_H
-
-#include "../src/DataEvent.cpp"
-#include "MaxLike.h"
-//#include "TPaveStateModify.h"
+#ifndef LIBRARIES_H 
+#define LIBRARIES_H 
 
 #include "TROOT.h"
 #include "TH1F.h"
@@ -14,6 +10,7 @@
 #include "TMath.h"
 #include "TLine.h"
 #include "TPad.h"
+#include "TChain.h"
 #include "TStyle.h"
 #include "TPaveStats.h"
 #include "TLatex.h"
@@ -26,9 +23,12 @@
 #include "TObjArray.h"
 #include "TPaveText.h"
 #include "TText.h"
+#include "TSystem.h" 
 #include "Math/Minimizer.h"
 #include "Math/Factory.h"
 #include "Math/Functor.h"
+#include "Math/IFunction.h"
+#include "TVirtualFitter.h"
 
 #include <sstream>
 #include <iostream>
@@ -46,4 +46,7 @@
 #include <assert.h>
 #include <chrono>
 #include <map>
+
 #endif
+
+

--- a/CodeCuts/include/MaxLike.h
+++ b/CodeCuts/include/MaxLike.h
@@ -1,17 +1,7 @@
 #ifndef MAXLIKE_H
 #define MAXLIKE_H
-#include "TVirtualFitter.h"
-#include "TStyle.h"
-//#include "/usr/local/root/include/Minuit2/FCNBase.h"
-//#include "TFitterMinuit.h"
-#include "TSystem.h" 
-#include "Math/Factory.h"
-//#include "Minuit2/FCNBase.h"
-#include "Math/Functor.h"
-#include "Math/Minimizer.h"
-#include "Math/IFunction.h"
-#include <vector>
-#include <iostream>
+
+#include "Libraries.h"
 
 using namespace std;
 
@@ -32,12 +22,36 @@ public:
         typedef vector<int>::size_type vec_sz;
         vec_sz m=Phi.size();
         for (vec_sz i=0; i<m; i++) {
-            sum+=-TMath::Log(1-GammaP[i]*x[0]*TMath::Cos(2*Phi[i]+2*x[1]*TMath::DegToRad()));
+	  sum+=-TMath::Log(1-GammaP[i]*x[0]*TMath::Cos((2*Phi[i]+2*x[1])*TMath::DegToRad()));
 	    
         }
         return sum;
     }
     double Up() const { return 0.5; }
 };
+
+
+class MaxLikeTF {
+
+private:
+    vector<double> Phi;
+    vector<double> GammaP;
+public:
+    MaxLikeTF(vector<double>  INPhi,  vector<double> INGammaP){
+        Phi=INPhi;
+        GammaP=INGammaP;
+    }
+  double operator() (double * x,double *p) const {
+        double sum=0;
+        typedef vector<int>::size_type vec_sz;
+        vec_sz m=Phi.size();
+        for (vec_sz i=0; i<m; i++) {
+	  sum+=-TMath::Log(1-GammaP[i]*x[0]*TMath::Cos((2*Phi[i]+2*x[1])*TMath::DegToRad()));
+	    
+        }
+        return sum;
+    }
+};
+
 #endif
 

--- a/CodeCuts/include/TPaveStateModify.h
+++ b/CodeCuts/include/TPaveStateModify.h
@@ -3,13 +3,14 @@
 
 #include "Libraries.h"
 
+using namespace std;
 
 class TPaveStateModify{
 protected:
-  TH1 *PrincipalHisto = NULL;
+  TH1 *PrincipalHisto 	= NULL;
   vector<TH1*> Histos;
-  TPaveStats *Pave = NULL;
-  TList *ListText  = NULL;
+  TPaveStats *Pave 	= NULL;
+  TList *ListText  	= NULL;
   double XSize;
   double YSize;
   double XStat;

--- a/CodeCuts/src/DataEvent.cpp
+++ b/CodeCuts/src/DataEvent.cpp
@@ -1,4 +1,8 @@
+#ifndef DATAEVENT_CPP
+#define DATAEVENT_CPP
+
 #include "../include/DataEvent.h"
+#include "../include/Libraries.h"
 
 DataEvent::DataEvent(string fileName, string treeName){
     SetUpTree(fileName, treeName);
@@ -164,4 +168,4 @@ int DataEvent::getEntries(){
     return loc_Tree->GetEntries();
 }
 
-
+#endif

--- a/CodeCuts/src/TPaveStateModify.C
+++ b/CodeCuts/src/TPaveStateModify.C
@@ -1,8 +1,10 @@
 #ifndef TPAVESTATEMODIFY_C
 #define TPAVESTATEMODIFY_C
 
-#include "../include/Libraries.h"
 #include "../include/TPaveStateModify.h"
+#include "../include/Libraries.h"
+
+using namespace std;
 
 TPaveStateModify::TPaveStateModify(TH1 *PH,TH1 *SH){
   PrincipalHisto=PH;


### PR DESCRIPTION
We changed the ellipse cut, added some histograms of Missing and invariant mass (lambda and Sigma)

- [x] IM Lambda vs IM Sigma
- [x] Make MIS Particles histograms 
1. Change the Kaon+ by Pion+
2. Change the Kaon+ by Proton
3. Change the Pion- by Kaon-
- [x] Make the cuts in MIS Particles histograms
- [x] English labes
- [x] Feedback